### PR TITLE
Pass contents of file to Parser instead of filepath

### DIFF
--- a/lib/greener/linter.rb
+++ b/lib/greener/linter.rb
@@ -32,7 +32,7 @@ module Greener
     def process_file(fname)
       @formatter_set.file_started
 
-      ast = Parser.new(fname).ast
+      ast = Parser.new(File.read(fname)).ast
 
       violations_in_file = []
 

--- a/lib/greener/parser.rb
+++ b/lib/greener/parser.rb
@@ -5,7 +5,7 @@ module Greener
   # Wrapper around Gherkin3's Parser
   class Parser
     def initialize(feature)
-      @feature = feature # filepath or String
+      @feature = feature # String containing file contents
     end
 
     # Return an Abstract Syntax Tree from a feature file


### PR DESCRIPTION
I ran into some trouble upgrading to Cucumber 2. Maybe I'm doing something wrong, but it looks like `Gherkin3::TokenScanner` initializes with the feature file contents rather than the filepath (https://github.com/cucumber/gherkin3/blob/master/ruby/lib/gherkin3/token_scanner.rb). I can move the file read into the Parser class and change the test (https://github.com/smoll/greener/blob/master/spec/greener/parser_spec.rb#L2) to use a dummy file instead if that's preferable.
